### PR TITLE
Logging of exceptions in eventloop

### DIFF
--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -54,13 +54,12 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
         loop: asyncio.AbstractEventLoop,
         context: dict,
     ) -> None:
-        # message is always present, but we'd prefer the exception if available
         if "exception" in context:
             exc = context["exception"]
             # CancelledErrors happen when we simply cancel the main task during
             # a normal restart procedure
             if not isinstance(exc, asyncio.CancelledError):
-                logger.error(exc)
+                logger.exception("Exception in event loop:")
         else:
             logger.error("unhandled error in event loop: %s", context["msg"])
 


### PR DESCRIPTION
Effectively this just reverts 946908b9. logger.exception seems to be behaving correctly now and printing the traceback.